### PR TITLE
Gracefully handle negative temperatures sent in two's complement

### DIFF
--- a/src/AM2302-Sensor.cpp
+++ b/src/AM2302-Sensor.cpp
@@ -8,6 +8,32 @@
 
 #include <AM2302-Sensor.h>
 
+namespace {
+   constexpr int16_t MIN_TEMPERATURE_RAW{-400};
+   constexpr int16_t MAX_TEMPERATURE_RAW{800};
+
+   bool is_valid_temperature_raw(int16_t value) {
+      return (value >= MIN_TEMPERATURE_RAW) && (value <= MAX_TEMPERATURE_RAW);
+   }
+
+   int16_t decode_temperature_raw(uint8_t msb, uint8_t lsb) {
+      const uint16_t raw = static_cast<uint16_t>((msb << 8) | lsb);
+      const int16_t sign_magnitude = -static_cast<int16_t>(raw & 0x7FFFU);
+      const int16_t twos_complement = static_cast<int16_t>(raw);
+
+      if (!(raw & 0x8000U)) {
+         return twos_complement;
+      }
+      if (is_valid_temperature_raw(sign_magnitude) && !is_valid_temperature_raw(twos_complement)) {
+         return sign_magnitude;
+      }
+      if (is_valid_temperature_raw(twos_complement) && !is_valid_temperature_raw(sign_magnitude)) {
+         return twos_complement;
+      }
+      return sign_magnitude;
+   }
+}
+
 AM2302::AM2302_Sensor::AM2302_Sensor(uint8_t pin) : _millis_last_read{0}, _pin{pin}
 {}
 
@@ -97,14 +123,7 @@ int8_t AM2302::AM2302_Sensor::read_sensor() {
 
    if (_checksum_ok) {
       _hum  = static_cast<uint16_t>((_data[0] << 8) | _data[1]);
-      if (_data[2] & 0x80) {
-         // negative temperature detected
-         _data[2] &= 0x7f;
-         _temp = -static_cast<int16_t>((_data[2] << 8) | _data[3]);
-      }
-      else {
-         _temp = static_cast<int16_t>((_data[2] << 8) | _data[3]);
-      }
+      _temp = decode_temperature_raw(_data[2], _data[3]);
       return AM2302_READ_OK;
    }
    else {


### PR DESCRIPTION
Updated the temperature decode path to handle negative AM2302 readings in an additional format encountered in the wild:

- default: sign-magnitude, which is the AM2302 spec and what the current implementation assumes
- new: 16-bit two's complement, which some compatible hardware appears to use (certain DHT22 boards)

The new logic decodes negative raw values using both interpretations and selects the one that falls within the sensor's valid temperature range (`-40.0C` to `80.0C`).

## Why

When a device reports negative temperatures in two's complement, the decoded readings become complete bogus.

Example from a freezer / sub-zero cooler:

- a real `-18.0C` in two's complement is raw `0xFF4C`
- the old decode path interpreted that as sign-magnitude and returned values in the `-3258C` <=> `-3264C` range

## Change

- preserves existing behavior as the standard path
- try two's complement decoding if the sign-magnitude method yields out-of-bounds values
- fall back to existing behavior if two's complement also fails to yield coherent values